### PR TITLE
perf(githubautotag): remove graphiteWidth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # mynewrepository
 
-
-BREAKING CHANGE: The graphiteWidth option has been removed.
-The default graphite width of 10mm is always used for performance reasons.
+This new line will break things


### PR DESCRIPTION
BREAKING CHANGE: The graphiteWidth option has been removed.

The default graphite width of 10mm is always used for performance reasons.